### PR TITLE
fix: Update requirements.txt Snyk Fix 08-07-2026

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ build==0.10.0
 wheel~=0.46.2
 lxml==6.1.0
 utils~=1.0.2
-keyring==23.13.1
 docutils==0.21.2
 pyparsing~=3.1.2
 config~=0.5.1


### PR DESCRIPTION
keyring isn't used anywhere in the SDK source, tests, or publish
workflow (auth is handled via token). Removing it drops the
transitive secretstorage@3.5.0 dependency, which Snyk flagged for
an unknown license with no available fix.