### PR TITLE
fix: version bump - resolve setuptools Snyk vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## _v2.7.1_
+
+### **Date: 22-July-2026**
+
+- Upgraded `setuptools` to `83.0.0` to resolve a Snyk-flagged Improper Unicode Encoding Handling issue.(Snyk Fix)
+
 ## _v2.7.0_
 
 ### **Date: 20-July-2026**

--- a/contentstack/__init__.py
+++ b/contentstack/__init__.py
@@ -42,7 +42,7 @@ def get_contentstack_endpoint(region='us', service='', omit_https=False):
 __title__ = 'contentstack-delivery-python'
 __author__ = 'contentstack'
 __status__ = 'debug'
-__version__ = 'v2.7.0'
+__version__ = 'v2.7.1'
 __endpoint__ = 'cdn.contentstack.io'
 __email__ = 'support@contentstack.com'
 __developer_email__ = 'mobile@contentstack.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 twython==3.9.1
-setuptools==80.3.1
+setuptools==83.0.0
 contentstack-utils==1.6.0
 python-dateutil==2.8.2
 requests==2.33.0


### PR DESCRIPTION
## Summary
- Upgraded `setuptools` from `80.3.1` to `83.0.0` to fix a Snyk-flagged Improper Unicode Encoding Handling issue
- Bumped SDK version to `v2.7.1` with a matching CHANGELOG entry

## Test plan
- [x] Verify `pip install -r requirements.txt` succeeds
- [x] Confirm Snyk re-scan no longer flags the setuptools vulnerability
- [x] Existing unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)