### PR TITLE
feat: add Taxonomy CDA support (list/fetch taxonomies, terms, hierarchy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## _v2.8.0_
+
+### **Date: 28-July-2026**
+
+- Added Taxonomy CDA support: `stack.taxonomy(uid)` now fetches a single published taxonomy (`.fetch()`), lists its terms (`.term().find()`), and fetches/traverses a single term (`.term(uid).fetch()/.locales()/.ancestors()/.descendants()`), with `.locale()`, `.include_fallback()`, `.include_branch()`, `.depth()`, `.skip()`, `.limit()`, `.include_count()`, and `.param()` chainable across the new classes. `stack.taxonomy()` (no uid) now also lists all published taxonomies via `.find()` when no filter is chained — existing entry-filter usage (`.in_()`, `.above()`, `.below()`, `.exists()`, etc. followed by `.find()`) is fully backward compatible and unchanged.
+
 ## _v2.7.1_
 
 ### **Date: 22-July-2026**

--- a/README.md
+++ b/README.md
@@ -126,6 +126,36 @@ image = stack.image_transform(url, {'width': 100, 'height': 100}).get_url()
 image = stack.image_transform(url, {'auto': 'webp'}).get_url()
 ```
 
+### Working with Taxonomies
+
+Taxonomies published to an environment/locale can be fetched directly via the Content Delivery API.
+
+```python
+# List all published taxonomies
+result = stack.taxonomy().limit(10).include_count().find()
+taxonomies = result['taxonomies']
+
+# Fetch a single taxonomy, with locale fallback
+taxonomy = stack.taxonomy('regions').locale('fr-fr').include_fallback().fetch()
+
+# List all terms in a taxonomy
+terms_result = stack.taxonomy('regions').term().locale('en-us').depth(3).find()
+
+# Fetch a single term
+term = stack.taxonomy('regions').term('california').fetch()
+
+# Term hierarchy traversal
+ancestors = stack.taxonomy('regions').term('san-francisco').depth(5).ancestors()
+descendants = stack.taxonomy('electronics').term('laptops').depth(2).descendants()
+locales = stack.taxonomy('regions').term('california').locales()
+```
+
+`stack.taxonomy()` (no uid) with a filter chained still filters entries by taxonomy, unchanged:
+
+```python
+result = stack.taxonomy().in_('taxonomies.category', ['category1', 'category2']).find()
+```
+
 ### Using the Sync API with Python SDK
 
 The Sync API takes care of syncing your Contentstack data with your application and ensures that the data is always

--- a/contentstack/__init__.py
+++ b/contentstack/__init__.py
@@ -42,7 +42,7 @@ def get_contentstack_endpoint(region='us', service='', omit_https=False):
 __title__ = 'contentstack-delivery-python'
 __author__ = 'contentstack'
 __status__ = 'debug'
-__version__ = 'v2.7.1'
+__version__ = 'v2.8.0'
 __endpoint__ = 'cdn.contentstack.io'
 __email__ = 'support@contentstack.com'
 __developer_email__ = 'mobile@contentstack.com'

--- a/contentstack/stack.py
+++ b/contentstack/stack.py
@@ -8,7 +8,7 @@ from contentstack.asset import Asset
 from contentstack.assetquery import AssetQuery
 from contentstack.contenttype import ContentType
 from contentstack.endpoint import Endpoint
-from contentstack.taxonomy import Taxonomy
+from contentstack.taxonomy import Taxonomy, TaxonomyQuery
 from contentstack.globalfields import GlobalField
 from contentstack.https_connection import HTTPSConnection
 from contentstack.image_transform import ImageTransform
@@ -202,13 +202,35 @@ class Stack:
         """
         return ContentType(self.http_instance, content_type_uid)
     
-    def taxonomy(self):
+    def taxonomy(self, taxonomy_uid: str = None):
         """
-        taxonomy defines the structure or schema of a page or a section
-        of your web or mobile property.
-        :return: taxonomy
+        Without taxonomy_uid: returns a TaxonomyQuery. Chain a filter
+        (in_, or_, and_, exists, above, below, equal_and_above, equal_and_below)
+        then find() to fetch entries filtered by taxonomy (legacy behavior,
+        unchanged). Or call find() directly with nothing chained to list all
+        published taxonomies from the Content Delivery API.
+
+        With taxonomy_uid: returns a Taxonomy for CDA access to that specific
+        published taxonomy (fetch(), term()).
+
+        :param taxonomy_uid: {str} -- (optional) unique identifier of the taxonomy.
+        :return: TaxonomyQuery or Taxonomy
+        -----------------------------
+        Example::
+
+            >>> import contentstack
+            >>> stack = contentstack.Stack('api_key', 'delivery_token', 'environment')
+            >>> # Legacy: filter entries by taxonomy
+            >>> result = stack.taxonomy().in_('taxonomies.color', ['red']).find()
+            >>> # New: list all published taxonomies
+            >>> result = stack.taxonomy().limit(10).find()
+            >>> # New: fetch a single published taxonomy
+            >>> result = stack.taxonomy('regions').fetch()
+        -----------------------------
         """
-        return Taxonomy(self.http_instance)
+        if taxonomy_uid:
+            return Taxonomy(self.http_instance, taxonomy_uid)
+        return TaxonomyQuery(self.http_instance)
     
     def global_field(self, global_field_uid=None):
         """

--- a/contentstack/taxonomy.py
+++ b/contentstack/taxonomy.py
@@ -1,43 +1,51 @@
 import json
-from urllib import parse
 from urllib.parse import quote
 
+from contentstack.error_messages import ErrorMessages
+from contentstack.utility import Utils
 
 
-class Taxonomy:
+class TaxonomyFilter:
+    """
+    Taxonomy entry-filter queries ($above, $below, $in, $exists, ...).
+    Use stack.taxonomy() to instantiate.
+
+    API Reference: https://www.contentstack.com/docs/developers/apis/content-delivery-api/#taxonomies
+    """
+
     def __init__(self, http_instance):
         self.http_instance = http_instance
         self._filters: dict = {}
 
-    def _add(self, field: str, condition: dict) -> "TaxonomyQuery":
+    def _add(self, field: str, condition: dict) -> "TaxonomyFilter":
         self._filters[field] = condition
         return self
 
-    def in_(self, field: str, terms: list) -> "TaxonomyQuery":
+    def in_(self, field: str, terms: list) -> "TaxonomyFilter":
         return self._add(field, {"$in": terms})
 
-    def or_(self, *conds: dict) -> "TaxonomyQuery":
+    def or_(self, *conds: dict) -> "TaxonomyFilter":
         return self._add("$or", list(conds))
 
-    def and_(self, *conds: dict) -> "TaxonomyQuery":
+    def and_(self, *conds: dict) -> "TaxonomyFilter":
         return self._add("$and", list(conds))
 
-    def exists(self, field: str) -> "TaxonomyQuery":
+    def exists(self, field: str) -> "TaxonomyFilter":
         return self._add(field, {"$exists": True})
 
-    def equal_and_below(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyQuery":
+    def equal_and_below(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyFilter":
         cond = {"$eq_below": term_uid, "levels": levels}
         return self._add(field, cond)
 
-    def below(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyQuery":
+    def below(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyFilter":
         cond = {"$below": term_uid, "levels": levels}
         return self._add(field, cond)
 
-    def equal_and_above(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyQuery":
+    def equal_and_above(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyFilter":
         cond = {"$eq_above": term_uid, "levels": levels}
         return self._add(field, cond)
 
-    def above(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyQuery":
+    def above(self, field: str, term_uid: str, levels: int = 10) -> "TaxonomyFilter":
         cond = {"$above": term_uid, "levels": levels}
         return self._add(field, cond)
 
@@ -62,3 +70,164 @@ class Taxonomy:
             url += f'&{other_params}'
         return self.http_instance.get(url)
 
+
+class TaxonomyQuery(TaxonomyFilter):
+    """
+    stack.taxonomy() — no uid.
+
+    Chain a filter (in_, or_, and_, exists, above, below, equal_and_above,
+    equal_and_below) then call find() to fetch entries filtered by taxonomy
+    (unchanged legacy behavior, inherited from TaxonomyFilter).
+
+    Call find() directly with nothing chained to list all published
+    taxonomies from the Content Delivery API instead.
+
+    Example::
+
+        >>> import contentstack
+        >>> stack = contentstack.Stack('api_key', 'delivery_token', 'environment')
+        >>> # Legacy: filter entries by taxonomy
+        >>> result = stack.taxonomy().in_('taxonomies.color', ['red']).find()
+        >>> # New: list all published taxonomies
+        >>> result = stack.taxonomy().limit(10).include_count().find()
+    """
+
+    def __init__(self, http_instance):
+        super().__init__(http_instance)
+        self._query_params = {}
+
+    def skip(self, skip: int) -> "TaxonomyQuery":
+        """Sets pagination offset for listing taxonomies.
+        :param skip: {int} -- number of taxonomies to skip
+        :return: TaxonomyQuery, so you can chain this call.
+        """
+        self._query_params['skip'] = skip
+        return self
+
+    def limit(self, limit: int) -> "TaxonomyQuery":
+        """Sets the maximum number of taxonomies to return.
+        :param limit: {int} -- max number of taxonomies to return
+        :return: TaxonomyQuery, so you can chain this call.
+        """
+        self._query_params['limit'] = limit
+        return self
+
+    def include_count(self) -> "TaxonomyQuery":
+        """Includes the total count of taxonomies in the response.
+        :return: TaxonomyQuery, so you can chain this call.
+        """
+        self._query_params['include_count'] = 'true'
+        return self
+
+    def param(self, key: str, value) -> "TaxonomyQuery":
+        """Adds an arbitrary query parameter to the list-taxonomies request
+        (e.g. 'locale').
+        :param key: {str} -- query parameter key
+        :param value: value for the query parameter
+        :return: TaxonomyQuery, so you can chain this call.
+        """
+        if None in (key, value):
+            raise KeyError(ErrorMessages.INVALID_KEY_VALUE_ARGS)
+        self._query_params[key] = value
+        return self
+
+    def find(self, params=None):
+        """
+        If a filter was chained (in_/or_/and_/exists/above/below/...), fetches
+        entries filtered by taxonomy — unchanged legacy behavior.
+        GET /taxonomies/entries?environment=...&query=...
+
+        Otherwise, fetches all published taxonomies from the CDA.
+        GET /taxonomies
+
+        :return: dict -- filtered entries, or {'taxonomies': [...], 'count'?: n}
+        """
+        if self._filters:
+            return super().find(params)
+        if params:
+            self._query_params.update(params)
+        url = f'{self.http_instance.endpoint}/taxonomies'
+        query_str = Utils.do_url_encode(self._query_params)
+        return self.http_instance.get(f'{url}?{query_str}' if query_str else url)
+
+
+class Taxonomy:
+    """
+    Represents a single published taxonomy from the Content Delivery API.
+    Use stack.taxonomy(uid) to instantiate.
+
+    Example::
+
+        >>> import contentstack
+        >>> stack = contentstack.Stack('api_key', 'delivery_token', 'environment')
+        >>> taxonomy = stack.taxonomy('regions').locale('fr-fr').include_fallback()
+        >>> result = taxonomy.fetch()
+    """
+
+    def __init__(self, http_instance, taxonomy_uid: str):
+        if not taxonomy_uid:
+            raise KeyError(ErrorMessages.INVALID_KEY_OR_VALUE)
+        self.http_instance = http_instance
+        self._taxonomy_uid = taxonomy_uid
+        self._url = f'{http_instance.endpoint}/taxonomies/{taxonomy_uid}'
+        self._query_params = {}
+
+    def term(self, term_uid: str = None):
+        """
+        Without term_uid: returns TermQuery for listing all terms in this taxonomy.
+        With term_uid: returns Term for a specific term.
+
+        :param term_uid: {str} -- (optional) unique identifier of the term.
+        :return: Term or TermQuery
+        """
+        from contentstack.term import Term, TermQuery
+        if term_uid:
+            return Term(self.http_instance, self._taxonomy_uid, term_uid)
+        return TermQuery(self.http_instance, self._taxonomy_uid)
+
+    def locale(self, locale: str) -> "Taxonomy":
+        """Sets the locale for this taxonomy fetch (e.g. 'en-us', 'fr-fr').
+        :param locale: {str} -- locale code
+        :return: Taxonomy, so you can chain this call.
+        """
+        self._query_params['locale'] = locale
+        return self
+
+    def include_fallback(self) -> "Taxonomy":
+        """Enables locale fallback through the branch hierarchy.
+        If the taxonomy is not published in the requested locale, falls back
+        to the parent locale in the branch hierarchy.
+        :return: Taxonomy, so you can chain this call.
+        """
+        self._query_params['include_fallback'] = 'true'
+        return self
+
+    def include_branch(self) -> "Taxonomy":
+        """Includes the _branch field in the response.
+        :return: Taxonomy, so you can chain this call.
+        """
+        self._query_params['include_branch'] = 'true'
+        return self
+
+    def param(self, key: str, value) -> "Taxonomy":
+        """Adds an arbitrary query parameter.
+        :param key: {str} -- query parameter key
+        :param value: value for the query parameter
+        :return: Taxonomy, so you can chain this call.
+        """
+        if None in (key, value):
+            raise KeyError(ErrorMessages.INVALID_KEY_VALUE_ARGS)
+        self._query_params[key] = value
+        return self
+
+    def fetch(self) -> dict:
+        """
+        Fetches this taxonomy from the CDA.
+        GET /taxonomies/{taxonomy_uid}
+
+        :return: dict -- the taxonomy object.
+        """
+        query_str = Utils.do_url_encode(self._query_params)
+        url = f'{self._url}?{query_str}' if query_str else self._url
+        response = self.http_instance.get(url)
+        return response.get('taxonomy', response)

--- a/contentstack/term.py
+++ b/contentstack/term.py
@@ -1,0 +1,194 @@
+from contentstack.error_messages import ErrorMessages
+from contentstack.utility import Utils
+
+
+class Term:
+    """
+    Represents a single published taxonomy term.
+    Supports hierarchy traversal: ancestors(), descendants(), locales().
+    Use stack.taxonomy(uid).term(term_uid) to instantiate.
+
+    Example::
+
+        >>> import contentstack
+        >>> stack = contentstack.Stack('api_key', 'delivery_token', 'environment')
+        >>> term = stack.taxonomy('regions').term('california')
+        >>> result = term.fetch()
+    """
+
+    def __init__(self, http_instance, taxonomy_uid: str, term_uid: str):
+        if not term_uid:
+            raise KeyError(ErrorMessages.INVALID_KEY_OR_VALUE)
+        self.http_instance = http_instance
+        self._url = f'{http_instance.endpoint}/taxonomies/{taxonomy_uid}/terms/{term_uid}'
+        self._query_params = {}
+
+    def depth(self, depth: int) -> "Term":
+        """Limits the depth of hierarchy traversal for ancestors()/descendants().
+        :param depth: {int} -- maximum hierarchy depth
+        :return: Term, so you can chain this call.
+        """
+        self._query_params['depth'] = depth
+        return self
+
+    def locale(self, locale: str) -> "Term":
+        """Sets the locale for this term fetch (e.g. 'en-us', 'fr-fr').
+        :param locale: {str} -- locale code
+        :return: Term, so you can chain this call.
+        """
+        self._query_params['locale'] = locale
+        return self
+
+    def include_fallback(self) -> "Term":
+        """Enables locale fallback through the branch hierarchy.
+        :return: Term, so you can chain this call.
+        """
+        self._query_params['include_fallback'] = 'true'
+        return self
+
+    def include_branch(self) -> "Term":
+        """Includes the _branch field in the response.
+        :return: Term, so you can chain this call.
+        """
+        self._query_params['include_branch'] = 'true'
+        return self
+
+    def param(self, key: str, value) -> "Term":
+        """Adds an arbitrary query parameter.
+        :param key: {str} -- query parameter key
+        :param value: value for the query parameter
+        :return: Term, so you can chain this call.
+        """
+        if None in (key, value):
+            raise KeyError(ErrorMessages.INVALID_KEY_VALUE_ARGS)
+        self._query_params[key] = value
+        return self
+
+    def _get(self, suffix: str = '', key: str = None):
+        url = f'{self._url}{suffix}'
+        query_str = Utils.do_url_encode(self._query_params)
+        response = self.http_instance.get(f'{url}?{query_str}' if query_str else url)
+        return response.get(key, response) if key else response
+
+    def fetch(self) -> dict:
+        """
+        Fetches this term.
+        GET /taxonomies/{taxonomy_uid}/terms/{term_uid}
+        :return: dict -- the term object.
+        """
+        return self._get(key='term')
+
+    def locales(self) -> dict:
+        """
+        Fetches all published localized versions of this term.
+        GET /taxonomies/{taxonomy_uid}/terms/{term_uid}/locales
+        :return: dict -- the localized terms.
+        """
+        return self._get('/locales', key='terms')
+
+    def ancestors(self) -> list:
+        """
+        Fetches all ancestor terms up to the root.
+        GET /taxonomies/{taxonomy_uid}/terms/{term_uid}/ancestors
+        :return: list -- the ancestor terms.
+        """
+        return self._get('/ancestors', key='terms')
+
+    def descendants(self) -> list:
+        """
+        Fetches all descendant terms.
+        GET /taxonomies/{taxonomy_uid}/terms/{term_uid}/descendants
+        :return: list -- the descendant terms.
+        """
+        return self._get('/descendants', key='terms')
+
+
+class TermQuery:
+    """
+    Query builder for fetching all terms in a taxonomy.
+    Use stack.taxonomy(uid).term() to instantiate.
+
+    Example::
+
+        >>> import contentstack
+        >>> stack = contentstack.Stack('api_key', 'delivery_token', 'environment')
+        >>> result = stack.taxonomy('regions').term().locale('en-us').depth(3).find()
+    """
+
+    def __init__(self, http_instance, taxonomy_uid: str):
+        self.http_instance = http_instance
+        self._url = f'{http_instance.endpoint}/taxonomies/{taxonomy_uid}/terms'
+        self._query_params = {}
+
+    def depth(self, depth: int) -> "TermQuery":
+        """Limits term hierarchy traversal depth.
+        :param depth: {int} -- maximum hierarchy depth
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['depth'] = depth
+        return self
+
+    def skip(self, skip: int) -> "TermQuery":
+        """Sets pagination offset.
+        :param skip: {int} -- number of terms to skip
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['skip'] = skip
+        return self
+
+    def limit(self, limit: int) -> "TermQuery":
+        """Sets the maximum number of terms to return.
+        :param limit: {int} -- max number of terms to return
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['limit'] = limit
+        return self
+
+    def locale(self, locale: str) -> "TermQuery":
+        """Filters terms by locale (e.g. 'en-us', 'fr-fr').
+        :param locale: {str} -- locale code
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['locale'] = locale
+        return self
+
+    def include_fallback(self) -> "TermQuery":
+        """Enables locale fallback through the branch hierarchy.
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['include_fallback'] = 'true'
+        return self
+
+    def include_branch(self) -> "TermQuery":
+        """Includes the _branch field in the response.
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['include_branch'] = 'true'
+        return self
+
+    def include_count(self) -> "TermQuery":
+        """Includes the total count of terms in the response.
+        :return: TermQuery, so you can chain this call.
+        """
+        self._query_params['include_count'] = 'true'
+        return self
+
+    def param(self, key: str, value) -> "TermQuery":
+        """Adds an arbitrary query parameter.
+        :param key: {str} -- query parameter key
+        :param value: value for the query parameter
+        :return: TermQuery, so you can chain this call.
+        """
+        if None in (key, value):
+            raise KeyError(ErrorMessages.INVALID_KEY_VALUE_ARGS)
+        self._query_params[key] = value
+        return self
+
+    def find(self) -> dict:
+        """
+        Fetches all terms in the taxonomy.
+        GET /taxonomies/{taxonomy_uid}/terms
+        :return: dict -- {'terms': [...], 'count'?: n}
+        """
+        query_str = Utils.do_url_encode(self._query_params)
+        return self.http_instance.get(f'{self._url}?{query_str}' if query_str else self._url)

--- a/tests/test_taxonomies.py
+++ b/tests/test_taxonomies.py
@@ -1,18 +1,47 @@
-import logging
+"""
+Taxonomy tests — legacy entry-filter queries plus Taxonomy CDA support (real API).
+
+Companion file tests/test_taxonomies_unit.py covers the mocked, no-network
+unit tests for the new CDA classes (Taxonomy, TaxonomyQuery, Term, TermQuery),
+including the merge-boundary test that pins the one behavior the
+no-breaking-change design hinges on.
+
+Split internally by test class:
+  - TestTaxonomyAPI              legacy entry-filter queries (in_, above, below, ...),
+                                  unchanged since before the CDA feature.
+  - TestTaxonomyCDA               the new CDA chaining, general coverage (list taxonomies,
+                                  single taxonomy/term, hierarchy). Targets the 'gadgets'
+                                  fixture — the only taxonomy on this stack with real
+                                  multi-level term hierarchy — for the tests that need one;
+                                  list-all-taxonomies and legacy-filter tests don't depend
+                                  on any specific taxonomy.
+  - TestTaxonomyLocalisation      tests against the 'gadgets' taxonomy fixture:
+                                  locale('fr-fr'), include_fallback() (including per-node
+                                  fallback), and depth-limited ancestor/descendant hierarchy
+                                  traversal (parent -> child -> grandchild).
+"""
 import unittest
 import config
 import contentstack
-import pytest
 
 API_KEY = config.APIKEY
 DELIVERY_TOKEN = config.DELIVERYTOKEN
 ENVIRONMENT = config.ENVIRONMENT
 HOST = config.HOST
 
+TAXONOMY_UID = config.TAXONOMY_UID
+LOCALE = config.TAXONOMY_LOCALE
+MASTER_LOCALE = config.TAXONOMY_MASTER_LOCALE
+
+
+# ===========================================================================
+# Legacy entry-filter taxonomy queries (real API) — unchanged
+# ===========================================================================
+
 class TestTaxonomyAPI(unittest.TestCase):
     def setUp(self):
         self.stack = contentstack.Stack(API_KEY, DELIVERY_TOKEN, ENVIRONMENT, host=HOST)
-    
+
     def test_01_taxonomy_complex_query(self):
         """Test complex taxonomy query combining multiple filters"""
         taxonomy = self.stack.taxonomy()
@@ -25,21 +54,21 @@ class TestTaxonomyAPI(unittest.TestCase):
         ).find({'limit': 10})
         if result is not None:
             self.assertIn('entries', result)
-            
+
     def test_02_taxonomy_in_query(self):
         """Test taxonomy query with $in filter"""
         taxonomy = self.stack.taxonomy()
         result = taxonomy.in_("taxonomies.category", ["category1", "category2"]).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_03_taxonomy_exists_query(self):
         """Test taxonomy query with $exists filter"""
         taxonomy = self.stack.taxonomy()
         result = taxonomy.exists("taxonomies.test1").find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_04_taxonomy_or_query(self):
         """Test taxonomy query with $or filter"""
         taxonomy = self.stack.taxonomy()
@@ -49,7 +78,7 @@ class TestTaxonomyAPI(unittest.TestCase):
         ).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_05_taxonomy_and_query(self):
         """Test taxonomy query with $and filter"""
         taxonomy = self.stack.taxonomy()
@@ -59,35 +88,35 @@ class TestTaxonomyAPI(unittest.TestCase):
         ).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_06_taxonomy_equal_and_below(self):
         """Test taxonomy query with $eq_below filter"""
         taxonomy = self.stack.taxonomy()
         result = taxonomy.equal_and_below("taxonomies.color", "blue", levels=1).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_07_taxonomy_below(self):
         """Test taxonomy query with $below filter"""
         taxonomy = self.stack.taxonomy()
         result = taxonomy.below("taxonomies.hierarchy", "parent_uid", levels=2).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_08_taxonomy_equal_and_above(self):
         """Test taxonomy query with $eq_above filter"""
         taxonomy = self.stack.taxonomy()
         result = taxonomy.equal_and_above("taxonomies.hierarchy", "child_uid", levels=3).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_09_taxonomy_above(self):
         """Test taxonomy query with $above filter"""
         taxonomy = self.stack.taxonomy()
         result = taxonomy.above("taxonomies.hierarchy", "child_uid", levels=2).find()
         if result is not None:
             self.assertIn('entries', result)
-    
+
     def test_10_taxonomy_find_with_params(self):
         """Test taxonomy find with additional parameters"""
         taxonomy = self.stack.taxonomy()
@@ -241,6 +270,464 @@ class TestTaxonomyAPI(unittest.TestCase):
         result = taxonomy.in_("taxonomies.category", ["test"]).find(None)
         if result is not None:
             self.assertIn('entries', result)
-    
+
+
+# ===========================================================================
+# Taxonomy CDA — real API, taxonomy-agnostic (dynamic discovery)
+# ===========================================================================
+
+class TestTaxonomyCDA(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.stack = contentstack.Stack(API_KEY, DELIVERY_TOKEN, ENVIRONMENT, host=HOST)
+        cls.taxonomy_uid = cls._discover_taxonomy_uid(cls.stack)
+        cls.term_uid = cls._discover_term_uid(cls.stack, cls.taxonomy_uid) if cls.taxonomy_uid else None
+        cls.hierarchy = cls._discover_hierarchy(cls.stack, cls.taxonomy_uid) if cls.taxonomy_uid else (None, None, None)
+
+    @staticmethod
+    def _discover_taxonomy_uid(stack):
+        """
+        Uses the 'gadgets' taxonomy fixture (config.TAXONOMY_UID) specifically —
+        it's the one taxonomy on this stack with real multi-level term hierarchy
+        and partial fr-fr translation, so the hierarchy/locale tests below have
+        real data to assert against instead of skipping.
+        """
+        result = stack.taxonomy(TAXONOMY_UID).fetch()
+        if isinstance(result, dict) and result.get('uid') == TAXONOMY_UID:
+            return TAXONOMY_UID
+        return None
+
+    @staticmethod
+    def _discover_term_uid(stack, taxonomy_uid):
+        """Fetches a real term uid within the discovered taxonomy."""
+        result = stack.taxonomy(taxonomy_uid).term().find()
+        if isinstance(result, dict) and result.get('terms'):
+            return result['terms'][0].get('uid')
+        return None
+
+    @staticmethod
+    def _discover_hierarchy(stack, taxonomy_uid):
+        """
+        Walks descendants() to find a real parent/child/grandchild term chain,
+        mirroring contentstack-dotnet's GetTermHierarchyAsync. Returns
+        (None, None, None) if no such chain exists in the fixture data.
+        """
+        terms_result = stack.taxonomy(taxonomy_uid).term().find()
+        terms = terms_result.get('terms', []) if isinstance(terms_result, dict) else []
+        for candidate_parent in terms:
+            parent_uid = candidate_parent.get('uid')
+            if not parent_uid:
+                continue
+            children = stack.taxonomy(taxonomy_uid).term(parent_uid).descendants()
+            children = children if isinstance(children, list) else (children or {}).get('descendants', [])
+            child_uid = children[0].get('uid') if children else None
+            if not child_uid:
+                continue
+            grandchildren = stack.taxonomy(taxonomy_uid).term(child_uid).descendants()
+            grandchildren = grandchildren if isinstance(grandchildren, list) else (grandchildren or {}).get('descendants', [])
+            grandchild_uid = grandchildren[0].get('uid') if grandchildren else None
+            if not grandchild_uid:
+                continue
+            return parent_uid, child_uid, grandchild_uid
+        return None, None, None
+
+    # ---------- List all taxonomies ----------
+
+    def test_01_list_all_taxonomies(self):
+        """GET /taxonomies returns a taxonomies collection."""
+        result = self.stack.taxonomy().find()
+        self.assertIsNotNone(result)
+        if 'taxonomies' in result:
+            self.assertIsInstance(result['taxonomies'], list)
+
+    def test_02_list_taxonomies_with_skip_limit(self):
+        """GET /taxonomies?skip=&limit= returns a paged subset."""
+        result = self.stack.taxonomy().skip(0).limit(1).find()
+        self.assertIsNotNone(result)
+        if 'taxonomies' in result:
+            self.assertLessEqual(len(result['taxonomies']), 1)
+
+    def test_03_list_taxonomies_with_include_count(self):
+        """GET /taxonomies?include_count=true includes a count field."""
+        result = self.stack.taxonomy().include_count().find()
+        self.assertIsNotNone(result)
+
+    # ---------- Legacy entry-filter behavior (non-regression) ----------
+
+    def test_04_legacy_filter_still_routes_to_entries(self):
+        """stack.taxonomy() with a filter chained still filters entries (unchanged)."""
+        result = self.stack.taxonomy().in_('taxonomies.category', ['test']).find()
+        if result is not None:
+            self.assertIn('entries', result)
+
+    # ---------- Single taxonomy ----------
+
+    def test_05_fetch_single_taxonomy(self):
+        """GET /taxonomies/{uid} returns the taxonomy object directly."""
+        if not self.taxonomy_uid:
+            self.skipTest("No taxonomy discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).fetch()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('uid'), self.taxonomy_uid)
+
+    def test_06_fetch_single_taxonomy_with_locale(self):
+        """GET /taxonomies/{uid}?locale=en-us returns a localized taxonomy."""
+        if not self.taxonomy_uid:
+            self.skipTest("No taxonomy discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).locale('en-us').include_fallback().fetch()
+        self.assertIsNotNone(result)
+
+    # ---------- List terms ----------
+
+    def test_07_find_all_terms(self):
+        """GET /taxonomies/{uid}/terms returns a terms collection."""
+        if not self.taxonomy_uid:
+            self.skipTest("No taxonomy discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term().find()
+        self.assertIsNotNone(result)
+        if 'terms' in result:
+            self.assertIsInstance(result['terms'], list)
+
+    def test_08_find_terms_with_locale_and_fallback(self):
+        """GET /taxonomies/{uid}/terms?locale=&include_fallback=true returns localized terms."""
+        if not self.taxonomy_uid:
+            self.skipTest("No taxonomy discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term() \
+            .locale('en-us').include_fallback().find()
+        self.assertIsNotNone(result)
+
+    def test_09_find_terms_with_depth(self):
+        """GET /taxonomies/{uid}/terms?depth=1 limits the returned hierarchy."""
+        if not self.taxonomy_uid:
+            self.skipTest("No taxonomy discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term().depth(1).find()
+        self.assertIsNotNone(result)
+
+    # ---------- Single term ----------
+
+    def test_10_fetch_single_term(self):
+        """GET /taxonomies/{uid}/terms/{termUid} returns the term object directly."""
+        if not self.term_uid:
+            self.skipTest("No term discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(self.term_uid).fetch()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('uid'), self.term_uid)
+
+    def test_11_fetch_term_with_include_branch(self):
+        """GET /taxonomies/{uid}/terms/{termUid}?include_branch=true includes branch info."""
+        if not self.term_uid:
+            self.skipTest("No term discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(self.term_uid) \
+            .include_branch().fetch()
+        self.assertIsNotNone(result)
+
+    def test_12_term_locales(self):
+        """GET /taxonomies/{uid}/terms/{termUid}/locales returns available locales."""
+        if not self.term_uid:
+            self.skipTest("No term discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(self.term_uid).locales()
+        self.assertIsNotNone(result)
+
+    def test_13_term_ancestors(self):
+        """GET /taxonomies/{uid}/terms/{termUid}/ancestors returns the ancestor chain."""
+        if not self.term_uid:
+            self.skipTest("No term discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(self.term_uid).ancestors()
+        self.assertIsNotNone(result)
+
+    def test_14_term_descendants(self):
+        """GET /taxonomies/{uid}/terms/{termUid}/descendants returns the descendant terms."""
+        if not self.term_uid:
+            self.skipTest("No term discovered on this stack — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(self.term_uid).descendants()
+        self.assertIsNotNone(result)
+
+    # ---------- Hierarchy depth (dynamically discovered chain) ----------
+
+    def test_15_descendants_depth_1_returns_only_direct_children(self):
+        """depth(1) on descendants() returns the direct child but not the grandchild."""
+        parent_uid, child_uid, grandchild_uid = self.hierarchy
+        if not parent_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(parent_uid).depth(1).descendants()
+        uids = [t.get('uid') for t in result] if isinstance(result, list) else \
+            [t.get('uid') for t in (result or {}).get('descendants', [])]
+        self.assertIn(child_uid, uids)
+        self.assertNotIn(grandchild_uid, uids)
+
+    def test_16_descendants_depth_2_includes_grandchildren(self):
+        """depth(2) on descendants() includes both the child and the grandchild."""
+        parent_uid, child_uid, grandchild_uid = self.hierarchy
+        if not parent_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(parent_uid).depth(2).descendants()
+        uids = [t.get('uid') for t in result] if isinstance(result, list) else \
+            [t.get('uid') for t in (result or {}).get('descendants', [])]
+        self.assertIn(child_uid, uids)
+        self.assertIn(grandchild_uid, uids)
+
+    def test_17_ancestors_for_grandchild_returns_full_chain(self):
+        """ancestors() for the grandchild returns both parent and child in the chain."""
+        parent_uid, child_uid, grandchild_uid = self.hierarchy
+        if not grandchild_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        result = self.stack.taxonomy(self.taxonomy_uid).term(grandchild_uid).ancestors()
+        uids = [t.get('uid') for t in result] if isinstance(result, list) else \
+            [t.get('uid') for t in (result or {}).get('ancestors', [])]
+        self.assertIn(child_uid, uids)
+        self.assertIn(parent_uid, uids)
+
+    # ---------- Feature-flag-off / not-found (TRD 1.3) ----------
+
+    def test_18_fetch_unknown_taxonomy_returns_error_body(self):
+        """
+        A nonexistent taxonomy uid returns a 404 error body. This SDK never
+        raises on HTTP-level errors (see contentstack/https_connection.py),
+        so the raw dict is asserted directly rather than expecting an exception.
+        """
+        result = self.stack.taxonomy('nonexistent_taxonomy_uid_xyz_123').fetch()
+        self.assertIsNotNone(result)
+        self.assertTrue('error_code' in result or 'errors' in result or 'taxonomy' not in result)
+
+
+# ===========================================================================
+# Taxonomy localisation — real API, 'gadgets' fixture
+# (mirrors contentstack-dotnet's TaxonomyLocalisationTest.cs test-for-test)
+# ===========================================================================
+
+class TestTaxonomyLocalisation(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.stack = contentstack.Stack(API_KEY, DELIVERY_TOKEN, ENVIRONMENT, host=HOST)
+        exists = cls.stack.taxonomy(TAXONOMY_UID).fetch()
+        if not isinstance(exists, dict) or exists.get('uid') != TAXONOMY_UID:
+            raise unittest.SkipTest(
+                f"'{TAXONOMY_UID}' taxonomy not found on this stack — publish it to run this suite.")
+        cls.term_uid = cls._get_first_term_uid(cls.stack)
+        cls.parent_uid, cls.child_uid, cls.grandchild_uid = cls._get_term_hierarchy(cls.stack)
+
+    @staticmethod
+    def _get_first_term_uid(stack):
+        """Fetches the first available term UID from the gadgets taxonomy."""
+        terms = stack.taxonomy(TAXONOMY_UID).term() \
+            .locale(LOCALE).include_fallback().find()
+        items = terms.get('terms', []) if isinstance(terms, dict) else []
+        return items[0].get('uid') if items else None
+
+    @staticmethod
+    def _get_term_hierarchy(stack):
+        """
+        Walks descendants() to find a real parent -> child -> grandchild
+        term chain. Returns (None, None, None) if no such chain exists.
+        """
+        terms = stack.taxonomy(TAXONOMY_UID).term().find()
+        items = terms.get('terms', []) if isinstance(terms, dict) else []
+        for candidate_parent in items:
+            parent_uid = candidate_parent.get('uid')
+            if not parent_uid:
+                continue
+            children = stack.taxonomy(TAXONOMY_UID).term(parent_uid).descendants()
+            children = children if isinstance(children, list) else []
+            child_uid = children[0].get('uid') if children else None
+            if not child_uid:
+                continue
+            grandchildren = stack.taxonomy(TAXONOMY_UID).term(child_uid).descendants()
+            grandchildren = grandchildren if isinstance(grandchildren, list) else []
+            grandchild_uid = grandchildren[0].get('uid') if grandchildren else None
+            if not grandchild_uid:
+                continue
+            return parent_uid, child_uid, grandchild_uid
+        return None, None, None
+
+    # ---------- 1. Fetch localized taxonomy ----------
+
+    def test_01_fetch_taxonomy_master_locale_returns_valid_object(self):
+        """Fetching without a locale returns the master-locale (en-us) taxonomy."""
+        result = self.stack.taxonomy(TAXONOMY_UID).fetch()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('uid'), TAXONOMY_UID)
+
+    def test_02_fetch_taxonomy_with_locale_returns_localized_name(self):
+        """locale('fr-fr') returns the genuinely-translated fr-fr taxonomy record."""
+        result = self.stack.taxonomy(TAXONOMY_UID).locale(LOCALE).fetch()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('uid'), TAXONOMY_UID)
+        self.assertEqual(result.get('locale'), LOCALE)
+        self.assertIsNotNone(result.get('name'))
+
+    # ---------- 2. Find all terms ----------
+
+    def test_03_find_all_terms_returns_collection(self):
+        """No locale filter returns the master-locale term collection."""
+        result = self.stack.taxonomy(TAXONOMY_UID).term().find()
+        self.assertIsNotNone(result)
+        self.assertTrue(len(result.get('terms', [])) > 0)
+
+    # ---------- 3. Find terms with locale ----------
+
+    def test_04_find_terms_with_locale_returns_localized_terms(self):
+        """locale('fr-fr') without fallback returns only genuinely-translated terms."""
+        result = self.stack.taxonomy(TAXONOMY_UID).term().locale(LOCALE).find()
+        self.assertIsNotNone(result)
+        for term in result.get('terms', []):
+            self.assertEqual(term.get('locale'), LOCALE)
+
+    def test_05_find_terms_with_locale_and_fallback_returns_all_terms(self):
+        """
+        include_fallback() returns every term, with per-node fallback: terms
+        translated into fr-fr come back as fr-fr, untranslated ones fall back
+        to en-us in the same response (not all-or-nothing).
+        """
+        result = self.stack.taxonomy(TAXONOMY_UID).term() \
+            .locale(LOCALE).include_fallback().find()
+        self.assertIsNotNone(result)
+        terms = result.get('terms', [])
+        self.assertTrue(len(terms) > 0)
+        locales_seen = {t.get('locale') for t in terms}
+        for term in terms:
+            self.assertIn(term.get('locale'), (LOCALE, MASTER_LOCALE))
+        # Demonstrates true per-node fallback rather than an all-or-nothing switch,
+        # only meaningful if the fixture has a genuine partial translation.
+        if len(locales_seen) > 1:
+            self.assertIn(LOCALE, locales_seen)
+            self.assertIn(MASTER_LOCALE, locales_seen)
+
+    # ---------- 4-7. Single term methods ----------
+
+    def test_06_fetch_single_term_with_locale_returns_localized_term(self):
+        if not self.term_uid:
+            self.skipTest("No term UID found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.term_uid) \
+            .locale(LOCALE).include_fallback().fetch()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('uid'), self.term_uid)
+
+    def test_07_term_locales_returns_locales_collection(self):
+        if not self.term_uid:
+            self.skipTest("No term UID found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.term_uid).locales()
+        self.assertIsNotNone(result)
+
+    def test_08_term_ancestors_returns_ancestors_collection(self):
+        if not self.term_uid:
+            self.skipTest("No term UID found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.term_uid).ancestors()
+        self.assertIsNotNone(result)
+
+    def test_09_term_descendants_returns_descendants_collection(self):
+        if not self.term_uid:
+            self.skipTest("No term UID found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.term_uid).descendants()
+        self.assertIsNotNone(result)
+
+    # ---------- 8. Term hierarchy - depth / include_branch ----------
+
+    def test_10_descendants_with_depth_1_returns_only_direct_children(self):
+        """depth(1) returns the direct child but not the grandchild."""
+        if not self.parent_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.parent_uid).depth(1).descendants()
+        uids = [t.get('uid') for t in result]
+        self.assertIn(self.child_uid, uids)
+        self.assertNotIn(self.grandchild_uid, uids)
+
+    def test_11_descendants_with_depth_2_includes_grandchildren(self):
+        """depth(2) includes both the direct child and the grandchild."""
+        if not self.parent_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.parent_uid).depth(2).descendants()
+        uids = [t.get('uid') for t in result]
+        self.assertIn(self.child_uid, uids)
+        self.assertIn(self.grandchild_uid, uids)
+
+    def test_12_ancestors_for_grandchild_returns_full_chain(self):
+        """ancestors() for the grandchild returns both the parent and the child."""
+        if not self.grandchild_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.grandchild_uid).ancestors()
+        uids = [t.get('uid') for t in result]
+        self.assertIn(self.child_uid, uids)
+        self.assertIn(self.parent_uid, uids)
+
+    def test_13_term_query_find_with_depth_limits_hierarchy_depth(self):
+        result = self.stack.taxonomy(TAXONOMY_UID).term().depth(1).find()
+        self.assertIsNotNone(result)
+        self.assertTrue(len(result.get('terms', [])) > 0)
+
+    def test_14_term_fetch_with_include_branch_returns_branch_info(self):
+        if not self.term_uid:
+            self.skipTest("No term UID found — skipping.")
+        result = self.stack.taxonomy(TAXONOMY_UID).term(self.term_uid).include_branch().fetch()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get('uid'), self.term_uid)
+
+    def test_15_descendants_with_locale_and_fallback_returns_localized_hierarchy(self):
+        """
+        depth(2) descendants with locale + include_fallback returns both the
+        child and grandchild, each individually translated or fallen back.
+        """
+        if not self.parent_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        terms = self.stack.taxonomy(TAXONOMY_UID).term(self.parent_uid) \
+            .locale(LOCALE).include_fallback().depth(2).descendants()
+        uids = [t.get('uid') for t in terms]
+        self.assertIn(self.child_uid, uids)
+        self.assertIn(self.grandchild_uid, uids)
+        for term in terms:
+            self.assertIn(
+                term.get('locale'), (LOCALE, MASTER_LOCALE),
+                f"Term '{term.get('uid')}' returned unexpected locale '{term.get('locale')}'"
+                f" — expected '{LOCALE}' (translated) or '{MASTER_LOCALE}' (fallback)."
+            )
+
+    def test_16_ancestors_with_locale_and_fallback_returns_localized_chain(self):
+        """ancestors() with locale + include_fallback returns a correctly localized/fallen-back chain."""
+        if not self.grandchild_uid:
+            self.skipTest("No parent/child/grandchild term chain found — skipping.")
+        terms = self.stack.taxonomy(TAXONOMY_UID).term(self.grandchild_uid) \
+            .locale(LOCALE).include_fallback().ancestors()
+        uids = [t.get('uid') for t in terms]
+        self.assertIn(self.child_uid, uids)
+        self.assertIn(self.parent_uid, uids)
+        for term in terms:
+            self.assertIn(term.get('locale'), (LOCALE, MASTER_LOCALE))
+
+    # ---------- 9. List all taxonomies ----------
+
+    def test_17_list_all_taxonomies_returns_collection(self):
+        result = self.stack.taxonomy().find()
+        self.assertIsNotNone(result)
+        self.assertTrue(len(result.get('taxonomies', [])) > 0)
+
+    def test_18_list_all_taxonomies_with_skip_and_limit_returns_paged_subset(self):
+        result = self.stack.taxonomy().skip(0).limit(1).find()
+        self.assertIsNotNone(result)
+        self.assertLessEqual(len(result.get('taxonomies', [])), 1)
+
+    def test_19_list_all_taxonomies_with_include_count_returns_count(self):
+        result = self.stack.taxonomy().include_count().find()
+        self.assertIsNotNone(result)
+
+    # ---------- 10. Not published in locale at all (contrast case, TRD 1.4) ----------
+
+    def test_20_taxonomy_not_published_in_locale_returns_404_without_fallback(self):
+        """
+        A taxonomy that has never been published in fr-fr (unlike gadgets,
+        which has partial fr-fr content) returns a 404 error body when
+        fetched with that locale and no fallback.
+        """
+        result = self.stack.taxonomy('category').locale(LOCALE).fetch()
+        if 'uid' in result:
+            self.skipTest("'category' taxonomy is published in fr-fr on this stack — contrast case not applicable.")
+        self.assertTrue(result.get('error_code') == 404 or 'errors' in result)
+
+    def test_21_taxonomy_list_not_published_in_locale_returns_empty_array(self):
+        """List endpoints return an empty array (not 404) when nothing matches the locale."""
+        result = self.stack.taxonomy('category').term().locale(LOCALE).find()
+        self.assertEqual(result.get('terms'), [])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_taxonomies_unit.py
+++ b/tests/test_taxonomies_unit.py
@@ -1,0 +1,283 @@
+"""
+Unit tests for Taxonomy CDA support (contentstack.taxonomy / contentstack.term).
+
+Mocked http_instance, no network calls — mirrors the pattern used in
+tests/test_early_fetch.py and contentstack-dotnet's TaxonomyUnitTests.cs
+(ported to Python idiom: query params are inspected directly via the
+instance's `_query_params` dict rather than via reflection).
+
+Companion to tests/test_taxonomies.py, which covers the legacy entry-filter
+queries and the real-API integration/localisation tests.
+"""
+import pytest
+from unittest.mock import MagicMock
+from urllib.parse import urlencode
+
+from contentstack.taxonomy import TaxonomyFilter, TaxonomyQuery, Taxonomy
+from contentstack.term import Term, TermQuery
+
+
+ENDPOINT = "https://api.contentstack.io/v3"
+
+
+@pytest.fixture
+def mock_http_instance():
+    mock = MagicMock()
+    mock.endpoint = ENDPOINT
+    mock.headers = {"environment": "test_env"}
+    mock.get = MagicMock(side_effect=lambda url: {"url": url})
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# The merge boundary — the one behavior the no-breaking-change design hinges on
+# ---------------------------------------------------------------------------
+
+class TestMergeBoundary:
+
+    def test_find_with_filter_chained_routes_to_legacy_entries_endpoint(self, mock_http_instance):
+        """A filter chained before find() must still hit /taxonomies/entries (unchanged)."""
+        tq = TaxonomyQuery(mock_http_instance)
+        result = tq.in_("taxonomies.category", ["test"]).find()
+        assert "/taxonomies/entries" in result["url"]
+        assert "query=" in result["url"]
+
+    def test_find_with_no_filter_routes_to_new_list_endpoint(self, mock_http_instance):
+        """No filter chained before find() must hit the new GET /taxonomies list endpoint."""
+        tq = TaxonomyQuery(mock_http_instance)
+        result = tq.find()
+        base = result["url"].split("?")[0]
+        assert base == f"{ENDPOINT}/taxonomies"
+        assert "/taxonomies/entries" not in result["url"]
+
+    def test_find_with_no_filter_but_query_params_still_routes_to_list_endpoint(self, mock_http_instance):
+        result = TaxonomyQuery(mock_http_instance).skip(0).limit(5).include_count().find()
+        base = result["url"].split("?")[0]
+        assert base == f"{ENDPOINT}/taxonomies"
+        assert "skip=0" in result["url"]
+        assert "limit=5" in result["url"]
+        assert "include_count=true" in result["url"]
+
+    def test_legacy_taxonomy_filter_class_unchanged(self, mock_http_instance):
+        """TaxonomyFilter (the renamed original class) behaves byte-for-byte as before."""
+        tf = TaxonomyFilter(mock_http_instance)
+        result = tf.above("taxonomies.hierarchy", "parent_uid", levels=2).find()
+        assert "/taxonomies/entries" in result["url"]
+        assert "environment=test_env" in result["url"]
+
+
+# ---------------------------------------------------------------------------
+# TaxonomyQuery — stack.taxonomy() list chainables
+# ---------------------------------------------------------------------------
+
+class TestTaxonomyQueryChainables:
+
+    def test_skip_sets_param_and_returns_self(self, mock_http_instance):
+        tq = TaxonomyQuery(mock_http_instance)
+        result = tq.skip(5)
+        assert result is tq
+        assert tq._query_params["skip"] == 5
+
+    def test_limit_sets_param_and_returns_self(self, mock_http_instance):
+        tq = TaxonomyQuery(mock_http_instance)
+        result = tq.limit(10)
+        assert result is tq
+        assert tq._query_params["limit"] == 10
+
+    def test_include_count_sets_param_and_returns_self(self, mock_http_instance):
+        tq = TaxonomyQuery(mock_http_instance)
+        result = tq.include_count()
+        assert result is tq
+        assert tq._query_params["include_count"] == "true"
+
+    def test_combined_chain_sets_all_params_together(self, mock_http_instance):
+        tq = TaxonomyQuery(mock_http_instance).skip(0).limit(10).include_count()
+        assert tq._query_params == {"skip": 0, "limit": 10, "include_count": "true"}
+
+    def test_param_sets_arbitrary_key(self, mock_http_instance):
+        tq = TaxonomyQuery(mock_http_instance)
+        result = tq.param("locale", "fr-fr")
+        assert result is tq
+        assert tq._query_params["locale"] == "fr-fr"
+
+    def test_param_raises_on_none_key_or_value(self, mock_http_instance):
+        tq = TaxonomyQuery(mock_http_instance)
+        with pytest.raises(KeyError):
+            tq.param(None, "value")
+        with pytest.raises(KeyError):
+            tq.param("key", None)
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy — stack.taxonomy(uid) single taxonomy
+# ---------------------------------------------------------------------------
+
+class TestTaxonomy:
+
+    def test_constructor_raises_on_none_uid(self, mock_http_instance):
+        with pytest.raises(KeyError):
+            Taxonomy(mock_http_instance, None)
+
+    def test_constructor_raises_on_empty_uid(self, mock_http_instance):
+        with pytest.raises(KeyError):
+            Taxonomy(mock_http_instance, "")
+
+    def test_locale_sets_param_and_returns_self(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        result = tax.locale("fr-fr")
+        assert result is tax
+        assert tax._query_params["locale"] == "fr-fr"
+
+    def test_include_fallback_sets_param(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        tax.include_fallback()
+        assert tax._query_params["include_fallback"] == "true"
+
+    def test_include_branch_sets_param(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        tax.include_branch()
+        assert tax._query_params["include_branch"] == "true"
+
+    def test_param_sets_arbitrary_key(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        tax.param("custom_key", "custom_value")
+        assert tax._query_params["custom_key"] == "custom_value"
+
+    def test_param_raises_on_none_key_or_value(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        with pytest.raises(KeyError):
+            tax.param(None, "value")
+        with pytest.raises(KeyError):
+            tax.param("key", None)
+
+    def test_fetch_builds_correct_url_and_unwraps_taxonomy_key(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"taxonomy": {"uid": "regions"}})
+        tax = Taxonomy(mock_http_instance, "regions").locale("fr-fr")
+        result = tax.fetch()
+        expected_params = urlencode({"locale": "fr-fr"})
+        mock_http_instance.get.assert_called_once_with(f"{ENDPOINT}/taxonomies/regions?{expected_params}")
+        assert result == {"uid": "regions"}
+
+    def test_fetch_without_params_omits_query_string(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"taxonomy": {"uid": "regions"}})
+        Taxonomy(mock_http_instance, "regions").fetch()
+        mock_http_instance.get.assert_called_once_with(f"{ENDPOINT}/taxonomies/regions")
+
+    def test_fetch_returns_raw_response_when_taxonomy_key_absent(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"error_code": 404})
+        result = Taxonomy(mock_http_instance, "regions").fetch()
+        assert result == {"error_code": 404}
+
+    def test_term_without_uid_returns_term_query(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        assert isinstance(tax.term(), TermQuery)
+
+    def test_term_with_uid_returns_term(self, mock_http_instance):
+        tax = Taxonomy(mock_http_instance, "regions")
+        assert isinstance(tax.term("california"), Term)
+
+
+# ---------------------------------------------------------------------------
+# Term — stack.taxonomy(uid).term(term_uid)
+# ---------------------------------------------------------------------------
+
+class TestTerm:
+
+    def test_constructor_raises_on_none_term_uid(self, mock_http_instance):
+        with pytest.raises(KeyError):
+            Term(mock_http_instance, "regions", None)
+
+    def test_depth_sets_param_and_returns_self(self, mock_http_instance):
+        term = Term(mock_http_instance, "regions", "california")
+        result = term.depth(3)
+        assert result is term
+        assert term._query_params["depth"] == 3
+
+    def test_locale_sets_param(self, mock_http_instance):
+        term = Term(mock_http_instance, "regions", "california")
+        term.locale("en-us")
+        assert term._query_params["locale"] == "en-us"
+
+    def test_include_fallback_sets_param(self, mock_http_instance):
+        term = Term(mock_http_instance, "regions", "california")
+        term.include_fallback()
+        assert term._query_params["include_fallback"] == "true"
+
+    def test_include_branch_sets_param(self, mock_http_instance):
+        term = Term(mock_http_instance, "regions", "california")
+        term.include_branch()
+        assert term._query_params["include_branch"] == "true"
+
+    def test_depth_then_include_branch_chains_both(self, mock_http_instance):
+        term = Term(mock_http_instance, "regions", "california").depth(2).include_branch()
+        assert term._query_params == {"depth": 2, "include_branch": "true"}
+
+    def test_fetch_builds_correct_url_and_unwraps_term_key(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"term": {"uid": "california"}})
+        result = Term(mock_http_instance, "regions", "california").fetch()
+        mock_http_instance.get.assert_called_once_with(f"{ENDPOINT}/taxonomies/regions/terms/california")
+        assert result == {"uid": "california"}
+
+    def test_locales_hits_locales_suffix_and_unwraps_terms_key(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"terms": [{"uid": "california"}]})
+        result = Term(mock_http_instance, "regions", "california").locales()
+        mock_http_instance.get.assert_called_once_with(
+            f"{ENDPOINT}/taxonomies/regions/terms/california/locales")
+        assert result == [{"uid": "california"}]
+
+    def test_ancestors_hits_ancestors_suffix_and_unwraps_terms_key(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"terms": [{"uid": "laptops"}]})
+        result = Term(mock_http_instance, "regions", "san-francisco").depth(5).ancestors()
+        expected_params = urlencode({"depth": 5})
+        mock_http_instance.get.assert_called_once_with(
+            f"{ENDPOINT}/taxonomies/regions/terms/san-francisco/ancestors?{expected_params}")
+        assert result == [{"uid": "laptops"}]
+
+    def test_descendants_hits_descendants_suffix_and_unwraps_terms_key(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"terms": [{"uid": "gaming_laptops"}]})
+        result = Term(mock_http_instance, "electronics", "laptops").descendants()
+        mock_http_instance.get.assert_called_once_with(
+            f"{ENDPOINT}/taxonomies/electronics/terms/laptops/descendants")
+        assert result == [{"uid": "gaming_laptops"}]
+
+
+# ---------------------------------------------------------------------------
+# TermQuery — stack.taxonomy(uid).term()
+# ---------------------------------------------------------------------------
+
+class TestTermQuery:
+
+    def test_skip_limit_include_count_depth_include_branch_chain_all_together(self, mock_http_instance):
+        tq = TermQuery(mock_http_instance, "regions") \
+            .skip(0).limit(10).include_count().depth(2).include_branch()
+        assert tq._query_params == {
+            "skip": 0, "limit": 10, "include_count": "true",
+            "depth": 2, "include_branch": "true",
+        }
+
+    def test_locale_sets_param(self, mock_http_instance):
+        tq = TermQuery(mock_http_instance, "regions")
+        tq.locale("en-us")
+        assert tq._query_params["locale"] == "en-us"
+
+    def test_include_fallback_sets_param(self, mock_http_instance):
+        tq = TermQuery(mock_http_instance, "regions")
+        tq.include_fallback()
+        assert tq._query_params["include_fallback"] == "true"
+
+    def test_param_sets_arbitrary_key(self, mock_http_instance):
+        tq = TermQuery(mock_http_instance, "regions")
+        tq.param("custom_key", "custom_value")
+        assert tq._query_params["custom_key"] == "custom_value"
+
+    def test_find_builds_correct_url(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"terms": []})
+        TermQuery(mock_http_instance, "regions").locale("en-us").depth(3).find()
+        expected_params = urlencode({"locale": "en-us", "depth": 3})
+        mock_http_instance.get.assert_called_once_with(
+            f"{ENDPOINT}/taxonomies/regions/terms?{expected_params}")
+
+    def test_find_without_params_omits_query_string(self, mock_http_instance):
+        mock_http_instance.get = MagicMock(return_value={"terms": []})
+        TermQuery(mock_http_instance, "regions").find()
+        mock_http_instance.get.assert_called_once_with(f"{ENDPOINT}/taxonomies/regions/terms")


### PR DESCRIPTION
## Summary
- Adds Taxonomy Publishing access via the CDA: list all taxonomies, fetch a taxonomy, list/fetch terms, and walk term hierarchy (locales, ancestors, descendants).
- `stack.taxonomy(uid)` scopes to a specific taxonomy; the existing `stack.taxonomy()` entry-filter behavior (`in_`/`above`/`below`/...) is untouched — no breaking change, no version bump for compatibility.
- Locale-aware: `locale()` + `include_fallback()` on `Taxonomy`/`Term`/`TermQuery`, verified against real per-node fallback and multi-level hierarchy data.

## API surface
```python
stack.taxonomy().find()                          # list all taxonomies
stack.taxonomy(uid).fetch()                       # fetch one taxonomy
stack.taxonomy(uid).term().find()                 # list terms
stack.taxonomy(uid).term(term_uid).fetch()        # fetch one term
stack.taxonomy(uid).term(term_uid).locales()
stack.taxonomy(uid).term(term_uid).ancestors()
stack.taxonomy(uid).term(term_uid).descendants()

# modifiers: locale, include_fallback, include_branch, depth, skip, limit, include_count, param
```

## Test plan
- [x] Unit tests (mocked, no network) — every chainable modifier, constructor validation, and the merge-boundary behavior (`tests/test_taxonomies_unit.py`)
- [x] Live integration tests against a real stack — all endpoints, locale/fallback (including per-node fallback), depth-limited hierarchy traversal (`tests/test_taxonomies.py`)
- [x] Full existing entry-filter suite passes unchanged — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)